### PR TITLE
Fix #30 - Text inputs bleed over question marks on Configuration page

### DIFF
--- a/doony.css
+++ b/doony.css
@@ -849,3 +849,10 @@ a.yuimenulabel, a.yuimenuitemlabel,
 #main-panel div[align=right] form[action=disable] {
   margin-top: 10px;
 }
+
+/* Configuration/Settings page styles */
+.setting-input {
+  box-sizing: border-box;
+  -webkit-box-sizing:border-box;
+  -moz-box-sizing: border-box;
+}

--- a/src/doony.scss
+++ b/src/doony.scss
@@ -797,3 +797,10 @@ a.yuimenulabel, a.yuimenuitemlabel,
 #main-panel div[align=right] form[action=disable] {
     margin-top: 10px;
 }
+
+/* Configuration/Settings page styles */
+.setting-input {
+    box-sizing: border-box;
+    -webkit-box-sizing:border-box;
+    -moz-box-sizing: border-box;
+}


### PR DESCRIPTION
This should fix the bleeding. Hat tip to SO: http://stackoverflow.com/questions/2371105/html-input-textbox-with-a-width-of-100-overflows-table-cells
