### PR TITLE
Correct "Build Now" and "Build with Parameters" buttons.

### DIFF
--- a/doony.js
+++ b/doony.js
@@ -357,21 +357,22 @@
     };
 
     var getButtonInfo = function() {
-      var links = Array.prototype.slice.call(document.querySelectorAll('a.task-link'));
-      var out = {};
-      var idx = -1
-      var end = links.length;
+      var buttonInfo = {};
 
-      while (++idx < end) {
-          if (links[idx].innerText.match(/Build with Parameters|Build Now/i)) {
-              out.innerHTML = links[idx].innerText;
-              out.href = links[idx].href;
-              out.hasParams = links[idx].innerText === 'Build with Parameters';
-              break;
-          }
-      };
+      $("a.task-link").each(function(index) {
+        var link = $(this);
 
-      return out;
+        if (!link.text().match(/Build with Parameters|Build Now/i)) {
+          return true;
+        }
+
+        buttonInfo.innerHTML = link.text();
+        buttonInfo.href = link.attr("href");
+        buttonInfo.hasParams = link.text() === "Build with Parameters";
+        return false;
+      });
+
+      return buttonInfo;
     };
 
     var createBuildButton = function() {


### PR DESCRIPTION
### Summary

Attempts to fix #5 by:
- Adding a `getButtonInfo` function which returns normalized button key/values (i.e. innerHTML, href, hasParams?).
- Following same approach as links in that there is a simple `onclick` vs. `jQuery.click`.
- Delegating to the Jenkins intrinsic `Ajax.Request` for dispatching request.
- Using `hoverNotification`.
### Screenshots
#### Job With Parameters

![](https://cloudup.com/ccvsliC8rY8+)
#### Job With Parameters...Next Page

![](https://cloudup.com/cdsTQ1frWrj+)
#### Normal Job

![Build Now](https://cloudup.com/cHxJmQ3mRlP+)
#### Normal Job after Click

![after click](https://cloudup.com/cmu2dJCA3LE+)
