### PR TITLE
Update URLs for CDN to latest revision

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,10 +84,10 @@ the default Jenkins styles.
    the CSS and Javascript URL's for this theme. You should find a place to host
    these, on a static server inside your cluster.
 
-    You can use these URL's:
+    You can use these URLs:
 
-        - https://cdnjs.cloudflare.com/ajax/libs/doony/1.1/js/doony.min.js
-        - https://cdnjs.cloudflare.com/ajax/libs/doony/1.1/css/doony.min.css
+        - https://cdnjs.cloudflare.com/ajax/libs/doony/1.5/js/doony.min.js
+        - https://cdnjs.cloudflare.com/ajax/libs/doony/1.5/css/doony.min.css
 
     Alternatively you can let Jenkins self host these files by putting them in `~/.jenkins/userContent`
     With the default Jenkins settings the files you use will then be:


### PR DESCRIPTION
Previously pointed to original release, now it points to the latest release that is on a CDN. This should probably be updated whenever a new release is cut (perhaps you have a checklist that could be updated.) Hope this helps!
