### PR TITLE
Replace balls for disabled projects with notbuilt replacement

### DIFF
--- a/doony.js
+++ b/doony.js
@@ -588,6 +588,7 @@ jQuery(function($) {
         replaceFloatyBall("img[src*='/yellow.png']", "warning");
         replaceFloatyBall("img[src*='/grey.png']", "aborted");
         replaceFloatyBall("img[src*='/nobuilt.png']", "notbuilt");
+        replaceFloatyBall("img[src*='/disabled.png']", "notbuilt");
     }, 10);
 
     if (isJobHomepage(window.location.pathname)) {


### PR DESCRIPTION
We're using Jenkins 1.554.1, and the balls for disabled projects were not being replaced.  This resolves that issue by replacing them with the notbuilt balls.  That seems to be effectively the same result as Jenkins' nobuilt.png and disabled.png balls, but maybe a different style is in order.
