### PR TITLE
Fix console output styling

### DIFF
--- a/doony.css
+++ b/doony.css
@@ -693,7 +693,8 @@ textarea {
  * too.
  */
 body > pre,
-#main-panel > pre {
+#main-panel > pre,
+.console-output {
   font-size: 14px;
   background-color: #111;
   color: #eee;


### PR DESCRIPTION
At least as of Jenkins 1.575, it looks like the console output element has a class that the style can be matched against.
